### PR TITLE
Updated Revolt.Net Link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ Revolt is a user-first, privacy-friendly chat platform built with modern web tec
 - [RevKit](https://github.com/Revolt-Unofficial-Clients/revkit) - A typed, class-oriented library for interacting with Revolt. Also includes additional packages for voice channels and command handler.
 
 ### C#
-- [Revolt.NET](https://www.nuget.org/packages/Revolt.Net/) - The .NET library for Revolt.
+- [Revolt.Net](https://github.com/nixonjoshua98/Revolt.Net) - The .Net library for Revolt.
 - [Revolution](https://github.com/li223/Revolution) - Yet another .Net Wrapper for Revolt.
 - [RevoltSharp](https://github.com/xXBuilderBXx/RevoltSharp) - C# lib with all the events and easy to use design.
 - [RevSharp](https://github.com/ktwrd/RevSharp) - C# Library with built-in cache focused on performance and ease-of-use.


### PR DESCRIPTION
Revolt.Net was previously worked on by another person (last updated 2022) @ https://github.com/Jan0660/Taco

I have recently taken over the project and own the Nuget package now (JNixon) and would like it to point to the new repository.
![image](https://github.com/insertish/awesome-revolt/assets/22799825/867ac666-089d-43ee-aae3-19e4f765e45e)
